### PR TITLE
Fix previously ignored errors when fetching ToolDAQFramework

### DIFF
--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -110,17 +110,22 @@ fi
 
 if [ $zmq -eq 1 ]
 then
-    git clone https://github.com/ToolDAQ/zeromq-4.0.7.git
-    
+    mkdir zeromq-4.0.7
     cd zeromq-4.0.7
+    git clone https://github.com/ToolDAQ/zeromq-4.0.7.git src
+
+    prefix=$PWD
+    cd src
     
-    ./configure --prefix=`pwd`
+    ./configure --prefix="$prefix"
     make -j $threads
     make install
+    cp -v include/zmq.hpp "$prefix/include"
     
-    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
+    unset prefix
     
-    cd ../
+    cd ../..
 fi
 
 if [ $boostflag -eq 1 ]

--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -138,7 +138,7 @@ then
     rm -rf INSTALL    
     mkdir install 
     
-    ./bootstrap.sh --prefix=`pwd`/install/  > /dev/null 2>/dev/null
+    ./bootstrap.sh --prefix="`pwd`/install/" --without-libraries=python > /dev/null 2>/dev/null
     ./b2 install iostreams -j $threads
     
     export LD_LIBRARY_PATH=`pwd`/install/lib:$LD_LIBRARY_PATH

--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 init=1
 tooldaq=1
 boostflag=1


### PR DESCRIPTION
Fix zeromq complains during `make install` phase.
Do not build Boost.Python --- does not compile against python-3.10.9 and not used in this project.
Enable error handling in GetToolDAQ.sh.